### PR TITLE
Add permissions boundary

### DIFF
--- a/terraform/aws/addons.tf
+++ b/terraform/aws/addons.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 resource "aws_iam_role" "ebs_provisioner" {
   name               = "${var.cluster_name}-eks-ebs-provisioner"
   assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc.json
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "ebs_provisioner" {

--- a/terraform/aws/cluster.tf
+++ b/terraform/aws/cluster.tf
@@ -13,8 +13,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "cluster_control_plane" {
-  name               = "${var.cluster_name}-eks-cluster-control-plane"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name                 = "${var.cluster_name}-eks-cluster-control-plane"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_controle_plane" {
@@ -54,6 +55,7 @@ module "cluster_autoscaler_irsa" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
   role_name = "cluster_autoscaler"
+  role_permissions_boundary_arn = var.permissions_boundary
 
   attach_cluster_autoscaler_policy = true
   cluster_autoscaler_cluster_ids = [

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -16,6 +16,7 @@ terraform {
 
 provider "aws" {
   region = var.region
+  default_tags { tags = var.aws_tags }
 }
 
 data "aws_vpc" "default" {

--- a/terraform/aws/nodes.tf
+++ b/terraform/aws/nodes.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "nodegroup" {
   name = "${var.cluster_name}-nodegroup-role"
+  permissions_boundary = var.permissions_boundary
 
   assume_role_policy = jsonencode({
     Statement = [{

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -12,6 +12,23 @@ variable "cluster_name" {
   EOT
 }
 
+variable "aws_tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  (Optional) AWS resource tags.
+  EOT
+}
+
+variable "permissions_boundary" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  (Optional) ARN of the policy that is used to set the permissions boundary for
+  the role.
+  EOT
+}
+
 variable "instance_type" {
   default     = "t3.large"
   description = <<-EOT


### PR DESCRIPTION
Adds variables to set AWS permissions boundary to make it easier to deploy on USGS's AWS account.
