### PR TITLE
Add permissions boundary and tag variables

### DIFF
--- a/terraform/aws/addons.tf
+++ b/terraform/aws/addons.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
 resource "aws_iam_role" "ebs_provisioner" {
   name               = "${var.cluster_name}-eks-ebs-provisioner"
   assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc.json
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "ebs_provisioner" {

--- a/terraform/aws/cluster.tf
+++ b/terraform/aws/cluster.tf
@@ -13,8 +13,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "cluster_control_plane" {
-  name               = "${var.cluster_name}-eks-cluster-control-plane"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name                 = "${var.cluster_name}-eks-cluster-control-plane"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_controle_plane" {
@@ -54,6 +55,7 @@ module "cluster_autoscaler_irsa" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
 
   role_name = "cluster_autoscaler"
+  role_permissions_boundary_arn = var.permissions_boundary
 
   attach_cluster_autoscaler_policy = true
   cluster_autoscaler_cluster_ids = [

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -20,7 +20,8 @@ provider "aws" {
 }
 
 data "aws_vpc" "default" {
-  default = true
+  default = var.aws_vpc.default
+  id      = var.aws_vpc.id
 }
 
 data "aws_subnets" "default" {

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -16,6 +16,7 @@ terraform {
 
 provider "aws" {
   region = var.region
+  default_tags { tags = var.aws_tags }
 }
 
 data "aws_vpc" "default" {

--- a/terraform/aws/nodes.tf
+++ b/terraform/aws/nodes.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "nodegroup" {
   name = "${var.cluster_name}-nodegroup-role"
+  permissions_boundary = var.permissions_boundary
 
   assume_role_policy = jsonencode({
     Statement = [{

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -29,6 +29,17 @@ variable "permissions_boundary" {
   EOT
 }
 
+variable "aws_vpc" {
+  type = map(string)
+  default = {
+    default = true
+    id = null
+  } 
+  description = <<-EOT
+  (Optional) AWS VPC configuration.
+  EOT
+}
+
 variable "instance_type" {
   default     = "t3.large"
   description = <<-EOT

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -34,7 +34,7 @@ variable "aws_vpc" {
   default = {
     default = true
     id = null
-  } 
+  }
   description = <<-EOT
   (Optional) AWS VPC configuration.
   EOT

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -12,6 +12,23 @@ variable "cluster_name" {
   EOT
 }
 
+variable "aws_tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  (Optional) AWS resource tags.
+  EOT
+}
+
+variable "permissions_boundary" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  (Optional) ARN of the policy that is used to set the permissions boundary for
+  the role.
+  EOT
+}
+
 variable "instance_type" {
   default     = "t3.large"
   description = <<-EOT


### PR DESCRIPTION
This PR resumes the changes proposed in #8. It adds permission boundary and tag variables, which are needed to deploy on the USGS cloud account. 

Initially, I tried adding an aws profile variable as well, but somehow this wasn't getting correctly passed through helm, such that deployment would fail, then I would need to run `aws eks update-kubeconfig` and add `config_path=~/.kube/config` to the helm provider in order to deploy the helm modules. For now, I think I can proceed without using a profile, so this isn't an issue.