### PR TITLE
Bump flink to 1.6.1

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -68,7 +68,7 @@ variable "max_instances" {
 }
 
 variable "flink_operator_version" {
-  default     = "1.5.0"
+  default     = "1.6.1"
   description = <<-EOT
   Version of Flink Operator to install.
   EOT


### PR DESCRIPTION
@ranchodeluxe and I are currently using 1.6.1 in our workflows and tests. I did see the latest release was 1.7.0, which I might start testing once I have HA and spot working. 

