### PR TITLE
WIP: Split job and task manager node groups

### DIFF
--- a/terraform/aws/nodes.tf
+++ b/terraform/aws/nodes.tf
@@ -29,21 +29,22 @@ resource "aws_iam_role_policy_attachment" "node_worker_ecr_policy_attachment" {
   role       = aws_iam_role.nodegroup.name
 }
 
-resource "aws_eks_node_group" "core_nodes" {
+resource "aws_eks_node_group" "flink_nodes" {
+  for_each = var.node_groups
   cluster_name    = aws_eks_cluster.cluster.name
-  node_group_name = "core"
+  node_group_name = each.value.node_group_name
   node_role_arn   = aws_iam_role.nodegroup.arn
 
   # FIXME: Need to restrict this to a single AZ maybe
   subnet_ids = data.aws_subnets.default.ids
 
-  instance_types = [var.instance_type]
+  instance_types = each.value.instance_types
 
-  capacity_type = var.capacity_type
+  capacity_type = each.value.capacity_type
 
   scaling_config {
     desired_size = 1
-    max_size     = var.max_instances
+    max_size     = each.value.max_instances
     min_size     = 0
   }
 

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -50,8 +50,8 @@ resource "helm_release" "flink_operator" {
         "prometheus.io/port" : "9999"
       }
       # Configure node groups
-      "kubernetes.jobmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : "$(var.node_groups.jobmanager.node_group_name)"}
-      "kubernetes.taskmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : "${var.node_groups.taskmanager.node_group_name}"}
+      "kubernetes.jobmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : var.node_groups.jobmanager.node_group_name}
+      "kubernetes.taskmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : var.node_groups.taskmanager.node_group_name}
     })
   }
 

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -39,16 +39,19 @@ resource "helm_release" "flink_operator" {
     type  = "string"
   }
 
-  # Enable prometheus metrics for all
   set {
     name = "defaultConfiguration.flink-conf\\.yaml"
     value = yamlencode({
+      # Enable prometheus metrics for all
       "kubernetes.operator.metrics.reporter.prom.class" : "org.apache.flink.metrics.prometheus.PrometheusReporter",
       "kubernetes.operator.metrics.reporter.prom.port" : "9999",
       "kubernetes.jobmanager.annotations" : {
         "prometheus.io/scrape" : "true"
         "prometheus.io/port" : "9999"
       }
+      # Configure node groups
+      "kubernetes.jobmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : "$(var.node_groups.jobmanager.node_group_name)"}
+      "kubernetes.taskmanager.node-selector" : {"eks.amazonaws.com/nodegroup" : "${var.node_groups.taskmanager.node_group_name}"}
     })
   }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -40,31 +40,24 @@ variable "aws_vpc" {
   EOT
 }
 
-variable "instance_type" {
-  default     = "t3.large"
-  description = <<-EOT
-  AWS Instance type used for nodes.
-  EOT
-}
+variable "node_groups" {
+  description = "Flink node groups."
+  type        = map(any)
 
-variable "capacity_type" {
-  default     = "ON_DEMAND"
-  description = <<-EOT
-  Whether to use ON_DEMAND or SPOT instances.
-  EOT
-  
-  validation {
-    condition     = contains(["ON_DEMAND", "SPOT"], var.capacity_type)
-    error_message = "The capcity_type value must be ON_DEMAND or SPOT."
+  default = {
+    jobmanager = {
+      node_group_name = "flink-jobmanager"
+      max_instances = 10
+      instance_types = ["t3.large"]
+      capacity_type = "ON_DEMAND"
+    },
+    taskmanager = {
+      node_group_name = "flink-taskmanager"
+      max_instances = 10
+      instance_types = ["t3.large"]
+      capacity_type = "SPOT"
+    }
   }
-}
-
-variable "max_instances" {
-  default     = 10
-  type        = number
-  description = <<-EOT
-  Maximum number of instances the autoscaler will scale the cluster up to.
-  EOT
 }
 
 variable "flink_operator_version" {


### PR DESCRIPTION
This PR would split the job and task managers among two node groups, such that job managers could use On Demand nodes, whereas task managers could use Spot.

I'm not sure of the best strategy for using Spot, so I'm advancing this one for testing and comment. 