### PR TITLE
WIP: Session deployment

### DIFF
--- a/manifests/pangeo-forge-session-deployment.yaml
+++ b/manifests/pangeo-forge-session-deployment.yaml
@@ -1,0 +1,33 @@
+#https://github.com/apache/flink-kubernetes-operator/blob/main/examples/basic-session-deployment-only.yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: pforge-flink-session
+spec:
+  image: flink:1.16
+  flinkVersion: v1_16
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+    podTemplate:
+      spec:
+        containers:
+          - name: "beam-worker-pool"
+            image: "apache/beam_python3.10_sdk:2.52.0"
+            ports:
+              - containerPort: 50000
+            readinessProbe:
+              tcpSocket:
+                port: 50000
+              periodSeconds: 10
+            #resource:
+            command: ["/opt/apache/beam/root"]
+            args: ["--worker_pool"]


### PR DESCRIPTION
This PR would configure Flink to run in session mode. Essentially, it would create a single job manager for the cluster, and all `pangeo-forge-recipes` would submit their jobs to that job manager.
One of the main advantages of this would be to centralize all infrastructure configuration configuration in `pangeo-forge-cloud-federation`.
Currently, infrastructure is spread across `pangeo-forge-cloud-federation`, `pangeo-forge-runner` and within the individual recipe's `config.py`, and this makes it difficult to configure the cluster. Ideally, we could have multiple node pools of on demand and spot, instances, high-availability job managers, reactive scaling, default failure strategies, etc and set all that within `pangeo-forge-cloud-federation`. Then the recipe and `pangeo-forge-runner` require minimal configuration, like setting parallelism and the job name.
