### PR TITLE
Update efs.yaml

### DIFF
--- a/helm-charts/flink-historyserver/templates/efs.yaml
+++ b/helm-charts/flink-historyserver/templates/efs.yaml
@@ -19,7 +19,7 @@ spec:
     - "ReadWriteMany"
   # 'persistentVolumeReclaimPolicy' means EFS volumes must be manually cleaned up when testing is done
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ .Release.Name }}-efs-flink-history
+  storageClassName: {{ .Release.Name }}-efs-flink-history-sc
   csi:
     driver: "efs.csi.aws.com"
     volumeHandle: "{{- .Values.efsFileSystemId }}"


### PR DESCRIPTION
I haven't been able to find real docs (besides ChatGPT and my own trial an error) that state the storage class name must be the same for both the PersistentVolume and the PersistentVolumeClaim but this is (I think) why the flink_historyserver deployment was failing for me. This PR updates `efs.yaml` so that the storage class name is the same for `PersistentVolume` and `PersistentVolumeClaim`.