### PR TITLE
Fix for all the configuration headaches 😏 

### DIFF
--- a/terraform/aws/flink-operator-helm-values.yaml
+++ b/terraform/aws/flink-operator-helm-values.yaml
@@ -3,17 +3,22 @@
 
 defaultConfiguration:
     flink-conf.yaml: |+
+      #### defaultConfiguration from pangeo-forge-cloud-federation ####
       taskmanager.numberOfTaskSlots: 1
       parallelism.default: 1
+
       # history server efs mounts
       historyserver.archive.fs.dir: /opt/history/jobs
       jobmanager.archive.fs.dir: /opt/history/jobs
+
       # metrics reporter for only the flink operator
       kubernetes.operator.metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
       kubernetes.operator.metrics.reporter.prom.port: 9999
+
       # metrics reporter for only the flink operator
       metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
       metrics.reporter.prom.port: 9999
+      #### defaultConfiguration from pangeo-forge-cloud-federation ####
 
 operatorPod:
   annotations:

--- a/terraform/aws/flink-operator-helm-values.yaml
+++ b/terraform/aws/flink-operator-helm-values.yaml
@@ -1,0 +1,24 @@
+
+
+
+defaultConfiguration:
+    flink-conf.yaml: |+
+      taskmanager.numberOfTaskSlots: 1
+      parallelism.default: 1
+      # history server efs mounts
+      historyserver.archive.fs.dir: /opt/history/jobs
+      jobmanager.archive.fs.dir: /opt/history/jobs
+      # metrics reporter for only the flink operator
+      kubernetes.operator.metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+      kubernetes.operator.metrics.reporter.prom.port: 9999
+      # metrics reporter for only the flink operator
+      metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+      metrics.reporter.prom.port: 9999
+
+operatorPod:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9999"
+
+metrics:
+  port: 9999

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     # FIXME: Investigate if we need the dynamodb locking here?
-    bucket = "pangeo-forge-federation-tfstate"
+    bucket = "pangeo-forge-federation-gcorradini-tfstate-v3"
     key    = "terraform"
     region = "us-west-2"
   }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     # FIXME: Investigate if we need the dynamodb locking here?
-    bucket = "pangeo-forge-federation-gcorradini-tfstate-v3"
+    bucket = "pangeo-forge-federation-tfstate"
     key    = "terraform"
     region = "us-west-2"
   }

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -25,44 +25,6 @@ resource "helm_release" "flink_operator" {
   wait       = true
   values = [file("${path.module}/flink-operator-helm-values.yaml")]
 
-#  # Let's grab metrics from the operator and put it into prometheus
-#  set {
-#    name  = "operatorPod.annotations.prometheus\\.io/scrape"
-#    value = "true"
-#    # Terraform seems to type-coerce ugh
-#    # Annotations *must* have string values, so we force these to be strings
-#    type = "string"
-#  }
-#  set {
-#    name  = "operatorPod.annotations.prometheus\\.io/port"
-#    value = "9999"
-#    type  = "string"
-#  }
-#
-#  # Enable prometheus metrics for all
-#  set {
-#    name = "defaultConfiguration.flink-conf\\.yaml"
-#    value = yamlencode({
-#      "kubernetes.operator.metrics.reporter.prom.factory.class" : "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
-#      "kubernetes.operator.metrics.reporter.prom.port" : "9999",
-#      "kubernetes.jobmanager.annotations" : {
-#        "prometheus.io/scrape" : "true",
-#        "prometheus.io/port" : "9999"
-#      },
-#      "kubernetes.taskmanager.annotations" : {
-#        "prometheus.io/scrape" : "true",
-#        "prometheus.io/port" : "9999"
-#      },
-#      "jobmanager.archive.fs.dir": var.historyserver_mount_path,
-#      "historyserver.archive.fs.dir": var.historyserver_mount_path,
-#    })
-#  }
-#
-#  set {
-#    name  = "metrics.port"
-#    value = "9999"
-#  }
-
   depends_on = [
     # cert-manager is required by flink-operator, as there is a webhook to be validated -
     # and that requires HTTPS! Note that it doesn't require letsencrypt, just cert-manager.

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -42,9 +42,13 @@ resource "helm_release" "flink_operator" {
   set {
     name = "defaultConfiguration.flink-conf\\.yaml"
     value = yamlencode({
-      "kubernetes.operator.metrics.reporter.prom.factory.class" : "org.apache.flink.metrics.prometheus.PrometheusReporter",
-      "kubernetes.operator.metrics.reporter.prom.factory.port" : "9999",
+      "kubernetes.operator.metrics.reporter.prom.factory.class" : "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+      "kubernetes.operator.metrics.reporter.prom.port" : "9999",
       "kubernetes.jobmanager.annotations" : {
+        "prometheus.io/scrape" : "true",
+        "prometheus.io/port" : "9999"
+      },
+      "kubernetes.taskmanager.annotations" : {
         "prometheus.io/scrape" : "true",
         "prometheus.io/port" : "9999"
       },

--- a/terraform/aws/operator.tf
+++ b/terraform/aws/operator.tf
@@ -23,44 +23,45 @@ resource "helm_release" "flink_operator" {
   chart      = "flink-kubernetes-operator"
   version    = var.flink_operator_version
   wait       = true
+  values = [file("${path.module}/flink-operator-helm-values.yaml")]
 
-  # Let's grab metrics from the operator and put it into prometheus
-  set {
-    name  = "operatorPod.annotations.prometheus\\.io/scrape"
-    value = "true"
-    # Terraform seems to type-coerce ugh
-    # Annotations *must* have string values, so we force these to be strings
-    type = "string"
-  }
-  set {
-    name  = "operatorPod.annotations.prometheus\\.io/port"
-    value = "9999"
-    type  = "string"
-  }
-
-  # Enable prometheus metrics for all
-  set {
-    name = "defaultConfiguration.flink-conf\\.yaml"
-    value = yamlencode({
-      "kubernetes.operator.metrics.reporter.prom.factory.class" : "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
-      "kubernetes.operator.metrics.reporter.prom.port" : "9999",
-      "kubernetes.jobmanager.annotations" : {
-        "prometheus.io/scrape" : "true",
-        "prometheus.io/port" : "9999"
-      },
-      "kubernetes.taskmanager.annotations" : {
-        "prometheus.io/scrape" : "true",
-        "prometheus.io/port" : "9999"
-      },
-      "jobmanager.archive.fs.dir": var.historyserver_mount_path,
-      "historyserver.archive.fs.dir": var.historyserver_mount_path,
-    })
-  }
-
-  set {
-    name  = "metrics.port"
-    value = "9999"
-  }
+#  # Let's grab metrics from the operator and put it into prometheus
+#  set {
+#    name  = "operatorPod.annotations.prometheus\\.io/scrape"
+#    value = "true"
+#    # Terraform seems to type-coerce ugh
+#    # Annotations *must* have string values, so we force these to be strings
+#    type = "string"
+#  }
+#  set {
+#    name  = "operatorPod.annotations.prometheus\\.io/port"
+#    value = "9999"
+#    type  = "string"
+#  }
+#
+#  # Enable prometheus metrics for all
+#  set {
+#    name = "defaultConfiguration.flink-conf\\.yaml"
+#    value = yamlencode({
+#      "kubernetes.operator.metrics.reporter.prom.factory.class" : "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+#      "kubernetes.operator.metrics.reporter.prom.port" : "9999",
+#      "kubernetes.jobmanager.annotations" : {
+#        "prometheus.io/scrape" : "true",
+#        "prometheus.io/port" : "9999"
+#      },
+#      "kubernetes.taskmanager.annotations" : {
+#        "prometheus.io/scrape" : "true",
+#        "prometheus.io/port" : "9999"
+#      },
+#      "jobmanager.archive.fs.dir": var.historyserver_mount_path,
+#      "historyserver.archive.fs.dir": var.historyserver_mount_path,
+#    })
+#  }
+#
+#  set {
+#    name  = "metrics.port"
+#    value = "9999"
+#  }
 
   depends_on = [
     # cert-manager is required by flink-operator, as there is a webhook to be validated -


### PR DESCRIPTION
#### Addresses #24 

* the classpaths and names were not correct
* leaving double quotes in the `flink-conf.yaml` made things unrecognizable and not picked up
* there are two different metrics reporters that need to be added 1) one only for the operator and 2) one for job/task managers it seems
*  could not get `kubernetes.jobmanager.annotations` to parse correctly on the operator and during deploys (they broke things) so removed these and put them in the actual runner manifests for now